### PR TITLE
CI: add Node 22 to version matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 18, 16]
+        node-version: [22, 20, 18, 16]
 
     env:
       YARN_IGNORE_NODE: 1
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build


### PR DESCRIPTION
Adds Node.js 22 to CI version matrix. Also runs the publish action in 22 instead of 20.

22 has been "current" Node.js version for good bit and is the active LTS version. I've been running this fork of Redlock in 22 for a while without issues, but it would be good to add it to official CI test battery too.

For successful test run, see [PR in this fork](https://github.com/stscoundrel/redlock/pull/1)