### PR TITLE
chore: declare correct license in pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "author": "Developers <developers@sesamecare.com>",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "packageManager": "yarn@3.6.0",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
Some automation tools that check for license issues use this field to figure out compliance and see the repository is MIT licensed, so made sure the pkg.json reflects that