### PR TITLE
CI: add Node 24 to version matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22, 20, 18, 16]
+        node-version: [24, 22, 20, 18, 16]
 
     env:
       YARN_IGNORE_NODE: 1


### PR DESCRIPTION
Add Node 24 to CI version matrix. 24 is the next LTS version.